### PR TITLE
Refactor: Remove JSON Patch from UserProfile updates

### DIFF
--- a/src/Pets.API/Controllers/UserProfileController.cs
+++ b/src/Pets.API/Controllers/UserProfileController.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
-using Microsoft.AspNetCore.JsonPatch;
 using Microsoft.AspNetCore.Mvc;
 using Pets.API.Responses.Dtos;
 using Pets.API.Services;
@@ -40,10 +39,10 @@ namespace Pets.API.Controllers
         }
 
         [HttpPatch]
-        public async Task<IActionResult> UpdateProfile([FromBody] JsonPatchDocument<UserProfileDto> patchDocument)
+        public async Task<IActionResult> UpdateProfile([FromBody] UserProfileDto userProfileDto)
         {
             var userId = _userManager.GetUserId(User);
-            var updateResult = await _userProfileService.UpdateUserProfile(userId, patchDocument);
+            var updateResult = await _userProfileService.UpdateUserProfile(userId, userProfileDto);
 
             if (!updateResult.Success)
             {

--- a/test/Pets.API.UnitTest/Controllers/UserProfileControllerTests.cs
+++ b/test/Pets.API.UnitTest/Controllers/UserProfileControllerTests.cs
@@ -1,0 +1,126 @@
+using Xunit;
+using Moq;
+using Pets.API.Controllers;
+using Pets.API.Services;
+using Pets.Db.Models;
+using Pets.API.Responses.Dtos;
+using Pets.API.Responses; // For UserProfileUpdateResult
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Identity;
+using System;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+
+// Assuming MockUserManager is accessible, e.g., if it's in a shared test utilities file or UserProfileServiceTests.cs is compiled alongside.
+// If not, it might need to be redefined or moved.
+// For simplicity, if it's in UserProfileServiceTests.cs, and these are part of the same test project, it should be fine.
+// Alternatively, could use a more basic Moq setup for UserManager here if MockUserManager helper is not directly usable.
+
+namespace Pets.API.UnitTest.Controllers
+{
+    public class UserProfileControllerTests
+    {
+        private readonly Mock<IUserProfileService> _mockUserProfileService;
+        private readonly Mock<IPetProfileService> _mockPetProfileService; // Added as it's a constructor dependency
+        private readonly Mock<UserManager<ApplicationUser>> _mockUserManager;
+        private readonly UserProfileController _controller;
+        private readonly string _testUserId = "test-user-id-guid";
+
+        public UserProfileControllerTests()
+        {
+            _mockUserProfileService = new Mock<IUserProfileService>();
+            _mockPetProfileService = new Mock<IPetProfileService>(); // Initialize mock
+
+            // Setup MockUserManager (assuming the helper is available or using basic Moq setup)
+            _mockUserManager = Services.MockUserManager.Create<ApplicationUser>(); // Using the one from UserProfileServiceTests namespace
+            
+            _controller = new UserProfileController(
+                _mockUserManager.Object,
+                _mockUserProfileService.Object,
+                _mockPetProfileService.Object // Pass the mock
+            );
+
+            // Setup ClaimsPrincipal for controller's User
+            var userClaims = new ClaimsPrincipal(new ClaimsIdentity(new Claim[]
+            {
+                new Claim(ClaimTypes.NameIdentifier, _testUserId),
+            }, "mock"));
+            _controller.ControllerContext = new ControllerContext()
+            {
+                HttpContext = new DefaultHttpContext() { User = userClaims }
+            };
+
+            // Setup UserManager GetUserId to return the testUserId
+            _mockUserManager.Setup(um => um.GetUserId(_controller.User)).Returns(_testUserId);
+        }
+
+        [Fact]
+        public async Task UpdateProfile_WithValidDto_WhenServiceSucceeds_ReturnsOk()
+        {
+            // Arrange
+            var userProfileDto = new UserProfileDto { Id = _testUserId, FirstName = "Test" };
+            var serviceResult = new UserProfileUpdateResult 
+            { 
+                Success = true, 
+                UpdatedProfile = userProfileDto 
+            };
+            _mockUserProfileService.Setup(s => s.UpdateUserProfile(_testUserId, userProfileDto))
+                .ReturnsAsync(serviceResult);
+
+            // Act
+            var result = await _controller.UpdateProfile(userProfileDto);
+
+            // Assert
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            Assert.Equal(userProfileDto, okResult.Value);
+            _mockUserProfileService.Verify(s => s.UpdateUserProfile(_testUserId, userProfileDto), Times.Once);
+        }
+
+        [Fact]
+        public async Task UpdateProfile_WhenServiceFailsWithErrors_ReturnsBadRequest()
+        {
+            // Arrange
+            var userProfileDto = new UserProfileDto { Id = _testUserId, FirstName = "Test" };
+            var errors = new List<IdentityError> { new IdentityError { Code = "Error", Description = "Service failed" } };
+            var serviceResult = new UserProfileUpdateResult 
+            { 
+                Success = false, 
+                Errors = errors 
+            };
+            _mockUserProfileService.Setup(s => s.UpdateUserProfile(_testUserId, userProfileDto))
+                .ReturnsAsync(serviceResult);
+
+            // Act
+            var result = await _controller.UpdateProfile(userProfileDto);
+
+            // Assert
+            var badRequestResult = Assert.IsType<BadRequestObjectResult>(result);
+            Assert.Equal(errors, badRequestResult.Value);
+        }
+
+        [Fact]
+        public async Task UpdateProfile_WhenServiceFailsWithoutErrors_ReturnsNotFound()
+        {
+            // This test case specifically checks the scenario where Success is false AND Errors is null
+            // which leads to a NotFoundResult based on the controller's logic:
+            // if (!updateResult.Success) { return updateResult.Errors != null ? BadRequest(updateResult.Errors) : NotFound(); }
+
+            // Arrange
+            var userProfileDto = new UserProfileDto { Id = _testUserId, FirstName = "Test" };
+            var serviceResult = new UserProfileUpdateResult 
+            { 
+                Success = false, 
+                Errors = null // Critical for this test case
+            };
+            _mockUserProfileService.Setup(s => s.UpdateUserProfile(_testUserId, userProfileDto))
+                .ReturnsAsync(serviceResult);
+
+            // Act
+            var result = await _controller.UpdateProfile(userProfileDto);
+
+            // Assert
+            Assert.IsType<NotFoundResult>(result);
+        }
+    }
+}

--- a/test/Pets.API.UnitTest/Services/UserProfileServiceTests.cs
+++ b/test/Pets.API.UnitTest/Services/UserProfileServiceTests.cs
@@ -1,0 +1,159 @@
+using Xunit;
+using Moq;
+using AutoMapper;
+using Pets.API.Services;
+using Pets.Db.Models;
+using Pets.API.Responses.Dtos;
+using Pets.API.Responses;
+using Pets.Db;
+using Pets.API.Helpers; // For AutoMapperProfile
+using Microsoft.AspNetCore.Identity;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore; // Required for InMemory database options if TestDbContextFactory doesn't abstract it fully
+
+namespace Pets.API.UnitTest.Services
+{
+    // Helper class to mock UserManager if not already available in the project
+    // Based on https://github.com/dotnet/aspnetcore/blob/main/src/Identity/testshared/MockHelpers.cs
+    public static class MockUserManager
+    {
+        public static Mock<UserManager<TUser>> Create<TUser>(IUserStore<TUser> store = null) where TUser : class
+        {
+            store = store ?? new Mock<IUserStore<TUser>>().Object;
+            var options = new Mock<Microsoft.Extensions.Options.IOptions<IdentityOptions>>();
+            var idOptions = new IdentityOptions();
+            idOptions.Lockout.DefaultLockoutTimeSpan = TimeSpan.FromMinutes(5);
+            idOptions.Lockout.MaxFailedAccessAttempts = 5;
+            idOptions.Lockout.AllowedForNewUsers = true;
+
+            options.Setup(o => o.Value).Returns(idOptions);
+            var userValidators = new List<IUserValidator<TUser>>();
+            var passwordValidators = new List<IPasswordValidator<TUser>>();
+            var userManager = new Mock<UserManager<TUser>>(store, options.Object,
+                new Mock<IPasswordHasher<TUser>>().Object,
+                userValidators, passwordValidators,
+                new Mock<ILookupNormalizer>().Object,
+                new Mock<IdentityErrorDescriber>().Object,
+                new Mock<IServiceProvider>().Object,
+                new Mock<Microsoft.Extensions.Logging.ILogger<UserManager<TUser>>>().Object);
+            return userManager;
+        }
+    }
+
+    public class UserProfileServiceTests
+    {
+        private readonly PetsDbContext _context;
+        private readonly UserProfileService _userProfileService;
+        private readonly IMapper _mapper;
+        private readonly Mock<UserManager<ApplicationUser>> _mockUserManager;
+        private readonly Mock<IGeocodingService> _mockGeocodingService;
+
+        public UserProfileServiceTests()
+        {
+            var factory = new TestDbContextFactory();
+            _context = factory.CreateDbContext();
+
+            var mapperConfig = new MapperConfiguration(cfg => cfg.AddProfile(new AutoMapperProfile()));
+            _mapper = mapperConfig.CreateMapper();
+
+            _mockUserManager = MockUserManager.Create<ApplicationUser>();
+            _mockGeocodingService = new Mock<IGeocodingService>();
+
+            _userProfileService = new UserProfileService(
+                _mockUserManager.Object,
+                _mapper,
+                _mockGeocodingService.Object,
+                _context
+            );
+        }
+
+        [Fact]
+        public async Task UpdateUserProfile_WhenProfileExists_ReturnsSuccessAndUpdateProfile()
+        {
+            // Arrange
+            var userId = Guid.NewGuid();
+            var existingProfileInfo = new UserProfileInfo
+            {
+                ApplicationUserId = userId,
+                FirstName = "OriginalFirst",
+                LastName = "OriginalLast",
+                PhoneNumber = "1234567890"
+            };
+            _context.UserProfileInfo.Add(existingProfileInfo);
+            await _context.SaveChangesAsync();
+
+            var updateDto = new UserProfileDto
+            {
+                Id = userId.ToString(),
+                FirstName = "UpdatedFirst",
+                LastName = "UpdatedLast",
+                PhoneNumber = "0987654321"
+            };
+
+            // Act
+            var result = await _userProfileService.UpdateUserProfile(userId.ToString(), updateDto);
+
+            // Assert
+            Assert.True(result.Success);
+            Assert.NotNull(result.UpdatedProfile);
+            Assert.Equal(updateDto.FirstName, result.UpdatedProfile.FirstName);
+            Assert.Equal(updateDto.LastName, result.UpdatedProfile.LastName);
+            Assert.Equal(updateDto.PhoneNumber, result.UpdatedProfile.PhoneNumber);
+            Assert.Equal(userId.ToString(), result.UpdatedProfile.Id);
+
+            var dbProfile = await _context.UserProfileInfo.FindAsync(userId);
+            Assert.NotNull(dbProfile);
+            Assert.Equal("UpdatedFirst", dbProfile.FirstName);
+            Assert.Equal("UpdatedLast", dbProfile.LastName);
+            Assert.Equal("0987654321", dbProfile.PhoneNumber);
+        }
+
+        [Fact]
+        public async Task UpdateUserProfile_WhenProfileNotFound_ReturnsFailure()
+        {
+            // Arrange
+            var userId = Guid.NewGuid().ToString();
+            var updateDto = new UserProfileDto
+            {
+                Id = userId,
+                FirstName = "TestFirst",
+                LastName = "TestLast",
+                PhoneNumber = "1231231234"
+            };
+
+            // Act
+            var result = await _userProfileService.UpdateUserProfile(userId, updateDto);
+
+            // Assert
+            Assert.False(result.Success);
+            Assert.Null(result.UpdatedProfile);
+            Assert.NotNull(result.Errors);
+            Assert.Contains(result.Errors, e => e.Code == "NotFound");
+        }
+
+        [Fact]
+        public async Task UpdateUserProfile_WithInvalidUserIdFormat_ReturnsFailure()
+        {
+            // Arrange
+            var invalidUserId = "not-a-guid";
+            var updateDto = new UserProfileDto
+            {
+                Id = invalidUserId,
+                FirstName = "TestFirst",
+                LastName = "TestLast"
+            };
+
+            // Act
+            var result = await _userProfileService.UpdateUserProfile(invalidUserId, updateDto);
+
+            // Assert
+            Assert.False(result.Success);
+            Assert.Null(result.UpdatedProfile);
+            Assert.NotNull(result.Errors);
+            Assert.Contains(result.Errors, e => e.Code == "InvalidUserIdFormat");
+        }
+    }
+}


### PR DESCRIPTION
- I modified UserProfileController.UpdateProfile to accept UserProfileDto instead of JsonPatchDocument.
- I updated UserProfileService.UpdateUserProfile and its interface accordingly to handle UserProfileDto.
- This change simplifies the update mechanism for user profiles, requiring the full DTO for updates.
- I added unit tests for both controller and service methods to ensure correct functionality and cover various scenarios.
- I verified that Swagger documentation no longer advertises 'application/json-patch+json' for the UserProfile update endpoint as a result of these changes.